### PR TITLE
Add 'apply' function to give access to the builder in a build pipeline.

### DIFF
--- a/parser/src/main/java/io/lindstrom/mpd/data/MPD.java
+++ b/parser/src/main/java/io/lindstrom/mpd/data/MPD.java
@@ -10,6 +10,7 @@ import java.time.Duration;
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Objects;
+import java.util.function.Function;
 
 @JsonPropertyOrder({
     "programInformations",
@@ -512,6 +513,10 @@ public class MPD {
         public Builder withSchemaLocation(String schemaLocation) {
             this.schemaLocation = schemaLocation;
             return this;
+        }
+
+        public Builder apply(Function<Builder, Builder> fn) {
+            return fn.apply(this);
         }
 
         public MPD build() {

--- a/parser/src/test/java/io/lindstrom/mpd/data/MPDTest.java
+++ b/parser/src/test/java/io/lindstrom/mpd/data/MPDTest.java
@@ -1,0 +1,28 @@
+package io.lindstrom.mpd.data;
+
+import java.time.Duration;
+import java.time.OffsetDateTime;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class MPDTest {
+
+    @Test
+    void itUsesTheSuppliedFunctionToModifyTheBuilder() {
+        MPD mpd = MPD.builder()
+                .withType(PresentationType.DYNAMIC)
+                .withAvailabilityStartTime(OffsetDateTime.parse("2024-03-27T13:00:00Z"))
+                .withPublishTime(OffsetDateTime.parse("2024-03-27T13:00:00Z"))
+                .apply(builder -> {
+                    if (OffsetDateTime.now().isAfter(OffsetDateTime.MIN)) {
+                        builder.withMaxSegmentDuration(Duration.ofMinutes(1));
+                    }
+                    return builder;
+                })
+                .build();
+
+        assertEquals(Duration.ofMinutes(1), mpd.getMaxSegmentDuration());
+    }
+
+}


### PR DESCRIPTION
When you have a long builder sequence, it is sometimes helpful to insert logic into the pipeline to avoid having to step out of the builder to conditionally add an element.

```java
MPD.Builder b = MPD.builder()
  // lots of builder elements
  .withField();

if (someCondition) {
  // build items when condition applies
  b = b.withSomething()
    .withSomethingElse();
}

return b.withOtherValues()
    .build();
```

Making use of a `java.util.function.Function` we can continue the pipeline and add the conditional without the top-level temporary variable:

```java
return MPD.builder()
  // lots of builder elements
  .withField();
  .apply(builder -> {
    if (someCondition) {
      return builder
        .withSomething()
        .withSomethingElse();
    }
    return builder;
  })
  .withOtherValues()
  .build();
```
