### PR TITLE
Replace P100Y with an hour equivilent.

### DIFF
--- a/parser/src/test/resources/vectors/Manifest.mpd.10
+++ b/parser/src/test/resources/vectors/Manifest.mpd.10
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<MPD availabilityStartTime="1970-01-01T00:00:00Z" id="Config part of url maybe?" maxSegmentDuration="PT2S" minBufferTime="PT2S" minimumUpdatePeriod="P100Y" profiles="urn:mpeg:dash:profile:isoff-live:2011,http://dashif.org/guidelines/dash-if-simple" publishTime="2017-07-18T22:09:18Z" timeShiftBufferDepth="PT5M" type="dynamic" ns1:schemaLocation="urn:mpeg:dash:schema:mpd:2011 DASH-MPD.xsd" xmlns="urn:mpeg:dash:schema:mpd:2011" xmlns:ns1="http://www.w3.org/2001/XMLSchema-instance">
+<MPD availabilityStartTime="1970-01-01T00:00:00Z" id="Config part of url maybe?" maxSegmentDuration="PT2S" minBufferTime="PT2S" minimumUpdatePeriod="PT876600H" profiles="urn:mpeg:dash:profile:isoff-live:2011,http://dashif.org/guidelines/dash-if-simple" publishTime="2017-07-18T22:09:18Z" timeShiftBufferDepth="PT5M" type="dynamic" ns1:schemaLocation="urn:mpeg:dash:schema:mpd:2011 DASH-MPD.xsd" xmlns="urn:mpeg:dash:schema:mpd:2011" xmlns:ns1="http://www.w3.org/2001/XMLSchema-instance">
    <ProgramInformation>
       <Title>Media Presentation Description from DASHI-IF live simulator</Title>
    </ProgramInformation>

--- a/parser/src/test/resources/vectors/Manifest.mpd.17
+++ b/parser/src/test/resources/vectors/Manifest.mpd.17
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<MPD availabilityStartTime="1970-01-01T00:00:00Z" id="Config part of url maybe?" maxSegmentDuration="PT2S" minBufferTime="PT2S" minimumUpdatePeriod="P100Y" profiles="urn:mpeg:dash:profile:isoff-live:2011,http://dashif.org/guidelines/dash-if-simple,http://dashif.org/guidelines/adin/app" publishTime="2017-07-18T22:09:22Z" timeShiftBufferDepth="PT5M" type="dynamic" ns1:schemaLocation="urn:mpeg:dash:schema:mpd:2011 DASH-MPD.xsd" xmlns="urn:mpeg:dash:schema:mpd:2011" xmlns:ns1="http://www.w3.org/2001/XMLSchema-instance">
+<MPD availabilityStartTime="1970-01-01T00:00:00Z" id="Config part of url maybe?" maxSegmentDuration="PT2S" minBufferTime="PT2S" minimumUpdatePeriod="PT876600H" profiles="urn:mpeg:dash:profile:isoff-live:2011,http://dashif.org/guidelines/dash-if-simple,http://dashif.org/guidelines/adin/app" publishTime="2017-07-18T22:09:22Z" timeShiftBufferDepth="PT5M" type="dynamic" ns1:schemaLocation="urn:mpeg:dash:schema:mpd:2011 DASH-MPD.xsd" xmlns="urn:mpeg:dash:schema:mpd:2011" xmlns:ns1="http://www.w3.org/2001/XMLSchema-instance">
    <ProgramInformation>
       <Title>Media Presentation Description from DASHI-IF live simulator</Title>
    </ProgramInformation>

--- a/parser/src/test/resources/vectors/Manifest.mpd.29
+++ b/parser/src/test/resources/vectors/Manifest.mpd.29
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<MPD availabilityStartTime="1970-01-01T00:00:00Z" id="Config part of url maybe?" maxSegmentDuration="PT2S" minBufferTime="PT2S" minimumUpdatePeriod="P100Y" profiles="urn:mpeg:dash:profile:isoff-live:2011,http://dashif.org/guidelines/dash-if-simple" publishTime="2017-07-18T22:09:59Z" timeShiftBufferDepth="PT5M" type="dynamic" ns1:schemaLocation="urn:mpeg:dash:schema:mpd:2011 DASH-MPD.xsd" xmlns="urn:mpeg:dash:schema:mpd:2011" xmlns:ns1="http://www.w3.org/2001/XMLSchema-instance">
+<MPD availabilityStartTime="1970-01-01T00:00:00Z" id="Config part of url maybe?" maxSegmentDuration="PT2S" minBufferTime="PT2S" minimumUpdatePeriod="PT876600H" profiles="urn:mpeg:dash:profile:isoff-live:2011,http://dashif.org/guidelines/dash-if-simple" publishTime="2017-07-18T22:09:59Z" timeShiftBufferDepth="PT5M" type="dynamic" ns1:schemaLocation="urn:mpeg:dash:schema:mpd:2011 DASH-MPD.xsd" xmlns="urn:mpeg:dash:schema:mpd:2011" xmlns:ns1="http://www.w3.org/2001/XMLSchema-instance">
    <ProgramInformation>
       <Title>Media Presentation Description from DASHI-IF live simulator</Title>
    </ProgramInformation>

--- a/parser/src/test/resources/vectors/Manifest.mpd.31
+++ b/parser/src/test/resources/vectors/Manifest.mpd.31
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<MPD availabilityStartTime="1970-01-01T00:00:00Z" id="Config part of url maybe?" maxSegmentDuration="PT2S" minBufferTime="PT2S" minimumUpdatePeriod="P100Y" profiles="urn:mpeg:dash:profile:isoff-live:2011,http://dashif.org/guidelines/dash-if-simple" publishTime="2017-07-18T22:10:01Z" timeShiftBufferDepth="PT5M" type="dynamic" ns1:schemaLocation="urn:mpeg:dash:schema:mpd:2011 DASH-MPD.xsd" xmlns="urn:mpeg:dash:schema:mpd:2011" xmlns:ns1="http://www.w3.org/2001/XMLSchema-instance">
+<MPD availabilityStartTime="1970-01-01T00:00:00Z" id="Config part of url maybe?" maxSegmentDuration="PT2S" minBufferTime="PT2S" minimumUpdatePeriod="PT876600H" profiles="urn:mpeg:dash:profile:isoff-live:2011,http://dashif.org/guidelines/dash-if-simple" publishTime="2017-07-18T22:10:01Z" timeShiftBufferDepth="PT5M" type="dynamic" ns1:schemaLocation="urn:mpeg:dash:schema:mpd:2011 DASH-MPD.xsd" xmlns="urn:mpeg:dash:schema:mpd:2011" xmlns:ns1="http://www.w3.org/2001/XMLSchema-instance">
    <ProgramInformation>
       <Title>Media Presentation Description from DASHI-IF live simulator</Title>
    </ProgramInformation>

--- a/parser/src/test/resources/vectors/Manifest.mpd.32
+++ b/parser/src/test/resources/vectors/Manifest.mpd.32
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<MPD availabilityStartTime="1970-01-01T00:00:00Z" id="Config part of url maybe?" maxSegmentDuration="PT2S" minBufferTime="PT2S" minimumUpdatePeriod="P100Y" profiles="urn:mpeg:dash:profile:isoff-live:2011,http://dashif.org/guidelines/dash-if-simple" publishTime="2017-07-18T22:10:02Z" timeShiftBufferDepth="PT5M" type="dynamic" ns1:schemaLocation="urn:mpeg:dash:schema:mpd:2011 DASH-MPD.xsd" xmlns="urn:mpeg:dash:schema:mpd:2011" xmlns:ns1="http://www.w3.org/2001/XMLSchema-instance">
+<MPD availabilityStartTime="1970-01-01T00:00:00Z" id="Config part of url maybe?" maxSegmentDuration="PT2S" minBufferTime="PT2S" minimumUpdatePeriod="PT876600H" profiles="urn:mpeg:dash:profile:isoff-live:2011,http://dashif.org/guidelines/dash-if-simple" publishTime="2017-07-18T22:10:02Z" timeShiftBufferDepth="PT5M" type="dynamic" ns1:schemaLocation="urn:mpeg:dash:schema:mpd:2011 DASH-MPD.xsd" xmlns="urn:mpeg:dash:schema:mpd:2011" xmlns:ns1="http://www.w3.org/2001/XMLSchema-instance">
    <ProgramInformation>
       <Title>Media Presentation Description from DASHI-IF live simulator</Title>
    </ProgramInformation>

--- a/parser/src/test/resources/vectors/Manifest.mpd.34
+++ b/parser/src/test/resources/vectors/Manifest.mpd.34
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<MPD availabilityStartTime="1970-01-01T00:00:00Z" id="Config part of url maybe?" maxSegmentDuration="PT2S" minBufferTime="PT2S" minimumUpdatePeriod="P100Y" profiles="urn:mpeg:dash:profile:isoff-live:2011,http://dashif.org/guidelines/dash-if-simple" publishTime="2017-07-18T22:10:32Z" timeShiftBufferDepth="PT5M" type="dynamic" ns1:schemaLocation="urn:mpeg:dash:schema:mpd:2011 DASH-MPD.xsd" xmlns="urn:mpeg:dash:schema:mpd:2011" xmlns:ns1="http://www.w3.org/2001/XMLSchema-instance">
+<MPD availabilityStartTime="1970-01-01T00:00:00Z" id="Config part of url maybe?" maxSegmentDuration="PT2S" minBufferTime="PT2S" minimumUpdatePeriod="PT876600H" profiles="urn:mpeg:dash:profile:isoff-live:2011,http://dashif.org/guidelines/dash-if-simple" publishTime="2017-07-18T22:10:32Z" timeShiftBufferDepth="PT5M" type="dynamic" ns1:schemaLocation="urn:mpeg:dash:schema:mpd:2011 DASH-MPD.xsd" xmlns="urn:mpeg:dash:schema:mpd:2011" xmlns:ns1="http://www.w3.org/2001/XMLSchema-instance">
    <ProgramInformation>
       <Title>Media Presentation Description from DASHI-IF live simulator</Title>
    </ProgramInformation>

--- a/parser/src/test/resources/vectors/Manifest.mpd.7
+++ b/parser/src/test/resources/vectors/Manifest.mpd.7
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<MPD availabilityStartTime="1970-01-01T00:00:00Z" id="Config part of url maybe?" maxSegmentDuration="PT2S" minBufferTime="PT2S" minimumUpdatePeriod="P100Y" profiles="urn:mpeg:dash:profile:isoff-live:2011,http://dashif.org/guidelines/dash-if-simple" publishTime="2017-07-18T22:09:14Z" timeShiftBufferDepth="PT5M" type="dynamic" ns1:schemaLocation="urn:mpeg:dash:schema:mpd:2011 DASH-MPD.xsd" xmlns="urn:mpeg:dash:schema:mpd:2011" xmlns:ns1="http://www.w3.org/2001/XMLSchema-instance">
+<MPD availabilityStartTime="1970-01-01T00:00:00Z" id="Config part of url maybe?" maxSegmentDuration="PT2S" minBufferTime="PT2S" minimumUpdatePeriod="PT876600H" profiles="urn:mpeg:dash:profile:isoff-live:2011,http://dashif.org/guidelines/dash-if-simple" publishTime="2017-07-18T22:09:14Z" timeShiftBufferDepth="PT5M" type="dynamic" ns1:schemaLocation="urn:mpeg:dash:schema:mpd:2011 DASH-MPD.xsd" xmlns="urn:mpeg:dash:schema:mpd:2011" xmlns:ns1="http://www.w3.org/2001/XMLSchema-instance">
    <ProgramInformation>
       <Title>Media Presentation Description from DASHI-IF live simulator</Title>
    </ProgramInformation>


### PR DESCRIPTION
In generating #10 I discovered that six of the unit tests did not pass. This was an odd failure. With some extra debugging I traced the failure to be checked at `MyDifferenceEvaluator`; where it is converting both sides of the test comparison to milliseconds.

With some extra logging I get:
```
Durations were different: P100Y -> 3155763600000 / PT876600H -> 3155760000000
```
It has converted `P100Y` to `3155763600000`.
`3,155,763,600` seconds;
`52,596,060` minutes;
`876,601` hours.

`876,600` looks like 100 years in hours; there are 24 leap years in the next 100 years. (there were 25 leap years in the last 100 years)

So where is that extra hour from? There would be the same number of daylight saving days in either case.

Given this comparison is using the `javax.xml.datatype.DatatypeFactory` to do the conversion, it feels like the issue is there.

Regardless of the cause if the descrepency this PR allows the tests to pass.
