### PR TITLE
Ignore unknown fields in mpd file

### DIFF
--- a/parser/src/main/java/io/lindstrom/mpd/MPDParser.java
+++ b/parser/src/main/java/io/lindstrom/mpd/MPDParser.java
@@ -62,7 +62,7 @@ public class MPDParser {
         return new XmlMapper(new XmlFactory(new WstxInputFactory(), new WstxPrefixedOutputFactory()), module)
                 .enable(SerializationFeature.INDENT_OUTPUT)
                 .setSerializationInclusion(JsonInclude.Include.NON_NULL)
-                .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, true)
+                .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
                 .configure(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE, true)
                 .setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY)
                 .setVisibility(PropertyAccessor.GETTER, JsonAutoDetect.Visibility.NONE);


### PR DESCRIPTION
Parser should ignore unknown fields in mpd file. instead of throwing exception 